### PR TITLE
fix: update Excel data type inference to handle larger sample sizes a…

### DIFF
--- a/src-tauri/src/reader/excel.rs
+++ b/src-tauri/src/reader/excel.rs
@@ -27,7 +27,7 @@ impl ExcelReader {
         Self {
             path,
             sheet_name: None,
-            infer_schema_length: 100,
+            infer_schema_length: 1000,
             try_parse_dates: false,
         }
     }
@@ -174,7 +174,9 @@ pub fn infer_field_schema(range: &Range<Data>, infer_schema_length: usize) -> Ap
     let num_columns = headers.len();
     let mut data_types: Vec<HashSet<DataType>> = vec![HashSet::new(); num_columns];
 
-    for row in range.rows().take(infer_schema_length) {
+    // Skip the header row — same as ExcelReader::finish — so column names
+    // do not pollute type inference as Utf8.
+    for row in range.rows().skip(1).take(infer_schema_length) {
         for (i, cell) in row.iter().enumerate() {
             if i < num_columns && !matches!(cell, Data::Empty) {
                 let inferred_type = infer_cell_data_type(cell);
@@ -187,22 +189,44 @@ pub fn infer_field_schema(range: &Range<Data>, infer_schema_length: usize) -> Ap
         .iter()
         .enumerate()
         .map(|(i, types)| {
-            let data_type = if types.is_empty() {
-                DataType::Utf8
-            } else if types.contains(&DataType::Int64) {
-                DataType::Int64
-            } else if types.contains(&DataType::Float64) {
-                DataType::Float64
-            } else if types.contains(&DataType::Timestamp(TimeUnit::Nanosecond, None)) {
-                DataType::Timestamp(TimeUnit::Nanosecond, None)
-            } else {
-                DataType::Utf8
-            };
+            let data_type = resolve_column_data_type(types);
             Field::new(headers[i].clone(), data_type, true)
         })
         .collect();
 
     Ok(Schema::new(fields))
+}
+
+/// Merge per-cell inferred types into a single column type.
+pub(crate) fn resolve_column_data_type(types: &HashSet<DataType>) -> DataType {
+    if types.is_empty() {
+        return DataType::Utf8;
+    }
+
+    let has_utf8 = types.contains(&DataType::Utf8);
+    let has_numeric =
+        types.contains(&DataType::Int64) || types.contains(&DataType::Float64);
+    let has_timestamp = types.contains(&DataType::Timestamp(TimeUnit::Nanosecond, None));
+
+    // Text mixed with numbers or dates cannot be read losslessly as a scalar
+    // column — fall back to Utf8 so every cell is preserved as text.
+    let category_count = [has_utf8, has_numeric, has_timestamp]
+        .iter()
+        .filter(|&&present| present)
+        .count();
+    if category_count > 1 {
+        return DataType::Utf8;
+    }
+
+    if types.contains(&DataType::Float64) {
+        DataType::Float64
+    } else if types.contains(&DataType::Int64) {
+        DataType::Int64
+    } else if has_timestamp {
+        DataType::Timestamp(TimeUnit::Nanosecond, None)
+    } else {
+        DataType::Utf8
+    }
 }
 
 /// Convert an Excel cell into a UTC timestamp in nanoseconds.

--- a/src-tauri/src/reader/excel_test.rs
+++ b/src-tauri/src/reader/excel_test.rs
@@ -1,5 +1,6 @@
 use super::excel::{
-    excel_cell_to_timestamp_nanos, infer_cell_data_type, infer_field_schema, ExcelReader,
+    excel_cell_to_timestamp_nanos, infer_cell_data_type, infer_field_schema,
+    resolve_column_data_type, ExcelReader,
 };
 use calamine::{Data, ExcelDateTime, ExcelDateTimeType, Range};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
@@ -140,9 +141,8 @@ fn test_infers_scalar_columns() {
 
 #[test]
 fn test_infer_field_schema_resolves_column_types() {
-    // 3 rows x 3 cols. Row 0 acts as the header (calamine treats the first row
-    // as headers and also feeds it into type inference as Utf8).
-    //   col0 "mix": Int + non-whole Float  -> Int64 wins
+    // 3 rows x 3 cols. Row 0 is the header (skipped during inference).
+    //   col0 "mix": Int + non-whole Float  -> Float64 (any float promotes column)
     //   col1 "dt" : DateTime cells          -> Timestamp(ns)
     //   col2      : entirely empty          -> Utf8 (empty-set default)
     let mut range: Range<Data> = Range::new((0, 0), (2, 2));
@@ -172,7 +172,7 @@ fn test_infer_field_schema_resolves_column_types() {
     assert_eq!(fields.len(), 3);
 
     assert_eq!(fields[0].name(), "mix");
-    assert_eq!(fields[0].data_type(), &DataType::Int64);
+    assert_eq!(fields[0].data_type(), &DataType::Float64);
 
     assert_eq!(fields[1].name(), "dt");
     assert_eq!(
@@ -182,6 +182,70 @@ fn test_infer_field_schema_resolves_column_types() {
 
     // Empty column resolves to the Utf8 default.
     assert_eq!(fields[2].data_type(), &DataType::Utf8);
+}
+
+#[test]
+fn test_infer_field_schema_promotes_to_float_when_any_fractional_value() {
+    // Regression: a column with mostly integers but one fractional value must
+    // be Float64, not Int64 (which would truncate via `as i64` on read).
+    let mut range: Range<Data> = Range::new((0, 0), (4, 0));
+    range.set_value((0, 0), Data::String("amount".to_string()));
+    range.set_value((1, 0), Data::Float(1.0));
+    range.set_value((2, 0), Data::Float(2.0));
+    range.set_value((3, 0), Data::Float(3.0));
+    range.set_value((4, 0), Data::Float(2.5));
+
+    let schema = infer_field_schema(&range, 100).expect("schema inferred");
+    assert_eq!(
+        schema.fields()[0].data_type(),
+        &DataType::Float64,
+        "one fractional cell must promote the whole column to Float64"
+    );
+}
+
+#[test]
+fn test_infer_field_schema_mixed_number_and_string_becomes_utf8() {
+    let mut range: Range<Data> = Range::new((0, 0), (4, 0));
+    range.set_value((0, 0), Data::String("score".to_string()));
+    range.set_value((1, 0), Data::Int(90));
+    range.set_value((2, 0), Data::Int(85));
+    range.set_value((3, 0), Data::String("N/A".to_string()));
+    range.set_value((4, 0), Data::Int(88));
+
+    let schema = infer_field_schema(&range, 100).expect("schema inferred");
+    assert_eq!(
+        schema.fields()[0].data_type(),
+        &DataType::Utf8,
+        "mixed numeric and text cells must fall back to Utf8"
+    );
+}
+
+#[test]
+fn test_resolve_column_data_type_rules() {
+    use std::collections::HashSet;
+
+    assert_eq!(resolve_column_data_type(&HashSet::new()), DataType::Utf8);
+
+    let mut ints = HashSet::new();
+    ints.insert(DataType::Int64);
+    assert_eq!(resolve_column_data_type(&ints), DataType::Int64);
+
+    let mut mixed_numeric = HashSet::new();
+    mixed_numeric.insert(DataType::Int64);
+    mixed_numeric.insert(DataType::Float64);
+    assert_eq!(
+        resolve_column_data_type(&mixed_numeric),
+        DataType::Float64,
+        "any fractional value promotes pure numeric columns"
+    );
+
+    let mut mixed_text_number = HashSet::new();
+    mixed_text_number.insert(DataType::Utf8);
+    mixed_text_number.insert(DataType::Int64);
+    assert_eq!(
+        resolve_column_data_type(&mixed_text_number),
+        DataType::Utf8
+    );
 }
 
 #[test]

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -410,7 +410,7 @@ const translations: Record<Language, Translations> = {
         name: "read_excel",
         description: "读取 Excel 文件为表。",
         inferSchema:
-          "是否自动推断数据类型。为 true 时，将根据前 100 行进行推断。",
+          "是否自动推断数据类型。为 true 时，将根据前 1000 行进行推断。",
         sheetName: "要读取的工作表名称，默认读取第一个 sheet。",
       },
       readParquet: {
@@ -669,7 +669,7 @@ const translations: Record<Language, Translations> = {
         name: "read_excel",
         description: "Read Excel file as table.",
         inferSchema:
-          "Whether to automatically infer data types. If true, the first 100 rows are used for inference.",
+          "Whether to automatically infer data types. If true, the first 1000 rows are used for inference.",
         sheetName: "Name of the sheet to read, defaults first sheet.",
       },
       readParquet: {


### PR DESCRIPTION
…nd improve type resolution

- Increased the schema inference length from 100 to 1000 rows for better accuracy in data type determination.
- Updated the `infer_field_schema` function to skip the header row during inference to prevent it from affecting type detection.
- Introduced a new `resolve_column_data_type` function to streamline the logic for determining the final data type based on inferred types, ensuring correct promotion of mixed numeric types to Float64.